### PR TITLE
main.c: Fix typo

### DIFF
--- a/Chapter_05/Src/main.c
+++ b/Chapter_05/Src/main.c
@@ -45,7 +45,7 @@ int main(void)
     const static uint32_t stackSize = 128;
     HWInit();
     SEGGER_SYSVIEW_Conf();
-    NVIC_SetPriorityGrouping( 0 ); // ensure proper priority grouping for freeRTOS
+    NVIC_SetPriorityGrouping( 0 ); // ensure proper priority grouping for FreeRTOS
 
     if (xTaskCreate(Task1, "task1", stackSize, NULL, tskIDLE_PRIORITY + 3, NULL) == pdPASS)
     {


### PR DESCRIPTION
Correct reference to FreeRtos with lower case 'f'